### PR TITLE
AP_Compass: fix missing rename

### DIFF
--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -449,7 +449,7 @@ void Compass::_detect_backends(void)
     _add_backend(AP_Compass_HMC5843::detect_i2c(*this, hal.i2c));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HMC5843_MPU6000
     _add_backend(AP_Compass_HMC5843::detect_mpu6000(*this));
-#elif  HAL_COMPASS_DEFAULT == HAL_COMPASS_AK8963_I2C && HAL_INS_AK8963_I2C_BUS == 1
+#elif  HAL_COMPASS_DEFAULT == HAL_COMPASS_AK8963_I2C && HAL_COMPASS_AK8963_I2C_BUS == 1
     _add_backend(AP_Compass_AK8963::detect_i2c(*this, hal.i2c1,
                                                HAL_COMPASS_AK8963_I2C_ADDR));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_AK8963_MPU9250_I2C


### PR DESCRIPTION
cb8355c (AP_HAL: fix compass define for bebop) renamed the constant in
AP_HAL but not in AP_Compass.